### PR TITLE
Update RegExp subclassing example to use a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,16 +135,13 @@ Note that `RegExp`'s @@match, @@matchAll, @@replace, @@search, and @@split symbo
 I hope this example demonstrates that one cannot subclass `RegExp` piecemeal and have a good time.
 
 ```js
-function R() { }
-Object.setPrototypeOf(R, RegExp);
-Object.setPrototypeOf(R.prototype, RegExp.prototype);
-R.prototype.exec = function() {
-  console.log("overridden");
-  return null;
-};
-// Define a new .global since RegExp#global throws on
-// non-RegExp-branded `this`
-Object.defineProperty(R.prototype, "global", { value: false });
+class R extends RegExp {
+	exec() {
+		console.log("overridden");
+		return null;
+	}
+}
+
 console.log("some string".match(new R("foo")))     // logs "overridden"
 ```
 


### PR DESCRIPTION
I'd suggest using a class in the RegExp example provided, for consistency with the rest of the examples, and the significantly improved readability. Afaict, the effects are the same.

I also let `R#global` fall through the prototype to the `RegExp#global` getter (which returns `false`, as R is now a RegExp class).